### PR TITLE
Remote unnecessary dbus import from cli.py

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 from spotipy import spotipy
-import dbus
 import argparse
 import sys
 


### PR DESCRIPTION
Since dbus seems to be a linux-only package, this was causing cli.py to
blow up on Mac OS X, and the import was unused in the cli.py file
anyway.
