### PR TITLE
Fix OS X AppleScript syntax error

### DIFF
--- a/spotipy/spotipy.py
+++ b/spotipy/spotipy.py
@@ -99,7 +99,7 @@ class Spotipy:
             subprocess.call([
                 'osascript',
                 '-e',
-                'tell app \'Spotify\' to play track \'%s\'' % uri
+                'tell app "Spotify" to play track "%s"' % uri
             ])
 
         print('\nPlaying: %s \n' % str(self._songs[index]['song']))


### PR DESCRIPTION
Fixes issue #6. Tested on OSX Yosemite.
