### PR TITLE
Moving all platform specific functionality into its own class.

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6,7 +6,7 @@ import sys
 
 class App:
     def __init__(self):
-        self.sptfy = spotipy.Spotipy()
+        self.sptfy = spotipy.get_spotipy_class_by_platform()()
 
         self.run()
 
@@ -73,7 +73,12 @@ class App:
                     song_input = raw_input('\nType song number and press <enter> to play. Press <enter> for new search.\n> ')
 
                 if song_input:
-                    self.sptfy.listen(int(song_input))
+                    try:
+                        self.sptfy.listen(int(song_input))
+                    # stop user entering something that is not a number.
+                    except ValueError:
+                        continue
+
 
 
 # Run the app


### PR DESCRIPTION
All platform specific behaviour is isolated in its own class.
cli.py uses the `get_spotipy_class_by_platform` to decide which to use.
Also fixed the dbus interface previous on Linux. It was previously
using self.interface.Prev() but this fails out. It is actually
Previous(). I was using this website to determine this:
http://www.frandieguez.com/blog/2010/11/playing-with-d-bus-interface-of-spotify-for-linux/
