### PR TITLE
adding process check and run spotify app

### DIFF
--- a/spotipy/spotipy.py
+++ b/spotipy/spotipy.py
@@ -114,13 +114,28 @@ def get_spotipy_class_by_platform():
 
 
 class DarwinSpotipy(Spotipy):
+    def __init__(self):
+        """
+            Check if there is a Spotify process running and if not, run Spotify.
+        """
+        try:
+            count = int(subprocess.check_output(["osascript",
+                      "-e", "tell application \"System Events\"",
+                      "-e", "count (every process whose name is \"Spotify\")",
+                      "-e", "end tell"]).strip()) 
+            if count == 0:
+                print "\n[OPENING SPOTIFY] The Spotify app was not open.\n"
+                self._make_osascript_call("tell application \"Spotify\" to activate")
+        except Exception:
+            sys.exit("You don't have Spotify installed. Please install it.")
+
     def _make_osascript_call(self, command):
         subprocess.call([
             'osascript',
             '-e',
             command
         ])
-
+ 
     def listen(self, index):
         uri = self._get_song_uri_at_index(index)
         self._make_osascript_call('tell app "Spotify" to play track "%s"' % uri)


### PR DESCRIPTION
Added a check for Spotify processes. If there are none then it opens the Spotify app (without bringing it to the foreground). This eliminates errors for the cli script where it will reject song selection, etc, when Spotify isn't currently running.
