### PR TITLE
Problem with imports in python 3.4 fix

### DIFF
--- a/pytify/cli.py
+++ b/pytify/cli.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import pytifylib
-from strategy import get_pytify_class_by_platform
+from .strategy import get_pytify_class_by_platform
 from menu import Menu
 import argparse
 import sys

--- a/pytify/cli.py
+++ b/pytify/cli.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-import .pytifylib
 from .strategy import get_pytify_class_by_platform
 from menu import Menu
 import argparse

--- a/pytify/cli.py
+++ b/pytify/cli.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import pytifylib
+import .pytifylib
 from .strategy import get_pytify_class_by_platform
 from menu import Menu
 import argparse

--- a/pytify/cli.py
+++ b/pytify/cli.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from .strategy import get_pytify_class_by_platform
-from menu import Menu
+from .menu import Menu
 import argparse
 import sys
 import curses

--- a/pytify/darwinpytify.py
+++ b/pytify/darwinpytify.py
@@ -1,6 +1,6 @@
 import sys
 import subprocess
-from pytifylib import Pytifylib
+from .pytifylib import Pytifylib
 
 
 class DarwinPytify(Pytifylib):

--- a/pytify/linuxpytify.py
+++ b/pytify/linuxpytify.py
@@ -1,6 +1,6 @@
 import sys
 import dbus
-from pytifylib import Pytifylib
+from .pytifylib import Pytifylib
 
 
 class LinuxPytify(Pytifylib):

--- a/pytify/menu.py
+++ b/pytify/menu.py
@@ -1,6 +1,6 @@
 import curses
 from curses import panel
-from strategy import get_pytify_class_by_platform
+from .strategy import get_pytify_class_by_platform
 
 
 """

--- a/pytify/strategy.py
+++ b/pytify/strategy.py
@@ -1,12 +1,13 @@
 from sys import platform
 
+
 def get_pytify_class_by_platform():
     if 'linux' in platform:
-        from linuxpytify import LinuxPytify
+        from .linuxpytify import LinuxPytify
 
         return LinuxPytify
     elif 'darwin' in platform:
-        from darwinpytify import DarwinPytify
+        from .darwinpytify import DarwinPytify
 
         return DarwinPytify
     else:


### PR DESCRIPTION
I had problem where the imports did not work in python 3.4 installed with pip
