### PR TITLE
added missing import. fixed #37

### DIFF
--- a/pytify/dbus/interface.py
+++ b/pytify/dbus/interface.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 import dbus
+import sys
 
 
 class Interface():

--- a/pytify/dbus/metadata.py
+++ b/pytify/dbus/metadata.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import, unicode_literals
-import sys
 from pytify.dbus.interface import Interface
 
 


### PR DESCRIPTION
fixes #37. 

In the dbus subpackage, there was a missing sys import in one and an unnecessary sys import in the other.

There may be more to this issue judging from the traceback, but I got an similar-ish error on linux as well and this change fixed mine.