### PR TITLE
better error handling when no credentials are added to bashrc file

### DIFF
--- a/pytify/pytifylib.py
+++ b/pytify/pytifylib.py
@@ -22,7 +22,7 @@ class Pytifylib:
         except spotipy.oauth2.SpotifyOauthError:
             print('Did not find Spotify credentials.')
 
-            print('Please visit https://github.com/bjarneo/pytify#credentials for more information')
+            print('Please visit https://github.com/bjarneo/pytify#credentials for more information.')
 
             sys.exit(1)
 

--- a/pytify/pytifylib.py
+++ b/pytify/pytifylib.py
@@ -5,7 +5,6 @@ from pytify.history import history
 from spotipy.oauth2 import SpotifyClientCredentials
 
 
-
 # Fetch songs with spotify api
 class Pytifylib:
     # hold songs
@@ -14,9 +13,18 @@ class Pytifylib:
     # limit output songs
     _limit = 15
 
-    # spotify lib
-    client_credentials_manager = SpotifyClientCredentials()
-    _spotify = spotipy.Spotify(client_credentials_manager=client_credentials_manager)
+    def _spotify(self):
+        return self.getCredentials()
+
+    def getCredentials(self):
+        try:
+            return spotipy.Spotify(client_credentials_manager=SpotifyClientCredentials())
+        except spotipy.oauth2.SpotifyOauthError:
+            print('Did not find Spotify credentials.')
+
+            print('Please visit https://github.com/bjarneo/pytify#credentials for more information')
+
+            sys.exit(1)
 
     # query
     def query(self, query):
@@ -34,7 +42,7 @@ class Pytifylib:
     # Search for song / album / artist
     def search(self, query, type='track,artist,album'):
         try:
-            response = self._spotify.search(q='+'.join(query.split()), type=type)
+            response = self._spotify().search(q='+'.join(query.split()), type=type)
 
         except spotipy.client.SpotifyException:
             print('Search went wrong? Please try again.')


### PR DESCRIPTION
Before
```
Traceback (most recent call last):
  File "/usr/local/bin/pytify", line 7, in <module>
    from pytify.cli import main
  File "/usr/local/lib/python3.6/site-packages/pytify/cli.py", line 3, in <module>
    import pytify.pytifylib
  File "/usr/local/lib/python3.6/site-packages/pytify/pytifylib.py", line 10, in <module>
    class Pytifylib:
  File "/usr/local/lib/python3.6/site-packages/pytify/pytifylib.py", line 18, in Pytifylib
    client_credentials_manager = SpotifyClientCredentials()
  File "/usr/local/lib/python3.6/site-packages/spotipy/oauth2.py", line 39, in __init__
    raise SpotifyOauthError('No client id')
spotipy.oauth2.SpotifyOauthError: No client id
```

Now
```
Did not find Spotify credentials.
Please visit https://github.com/bjarneo/pytify#credentials for more information.
```
