### PR TITLE
Upgrade Pytify to support prompt_toolkit v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Contributions are appreciated.
 - [@wohlfea](https://github.com/wohlfea) - Made it compatible with python 3.5
 - [@ddiddi](https://github.com/ddiddi) - Added search phrase history browsing. (auto complete)
 - [@kmatt](https://github.com/kmatt) - Minor UX changes
+- [@bharath123](https://github.com/bharath-123) - Updated Pytify to use prompt_toolkit v2
 - .... and other.. please add your name and code update!
 
 ### Logo

--- a/pytify/cli.py
+++ b/pytify/cli.py
@@ -69,8 +69,11 @@ class App:
         )
 
         while 1:
-            search_input = custom_prompt(self.pytify.get_current_playing())
-
+            try:
+                search_input = custom_prompt(self.pytify.get_current_playing())
+            except KeyboardInterrupt:
+                continue
+            
             if self.command.run(search_input):
                 continue
 
@@ -84,6 +87,4 @@ def main():
     try:
         App()
     except EOFError:
-        print('\n Closing application...\n')
-    except KeyboardInterrupt:
         print('\n Closing application...\n')

--- a/pytify/prompt.py
+++ b/pytify/prompt.py
@@ -1,64 +1,69 @@
 from __future__ import absolute_import, unicode_literals
 import getpass
 import os
-from prompt_toolkit import prompt, AbortAction
+from prompt_toolkit import PromptSession
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
-from prompt_toolkit.token import Token
-from prompt_toolkit.styles import style_from_dict
-from prompt_toolkit.contrib.completers import WordCompleter
+from prompt_toolkit.formatted_text import PygmentsTokens
+from prompt_toolkit.styles import Style
+from prompt_toolkit.completion import WordCompleter, ThreadedCompleter
 from pytify.history import history
 
-
-style = style_from_dict({
-    Token.Username:  '#84bd00 italic',
-    Token.At:        '#999999',
-    Token.Host:      '#84bd00',
-    Token.Separator: '#84bd00',
-    Token.Text:      '#e6e6e6',
-    Token.Arrow:     '#999999',
-    Token.SelectedText: 'reverse underline',
-    Token.Toolbar: '#e6e6e6 bg:#262626',
+style = Style.from_dict({
+    'username':  '#84bd00 italic',
+    'at':        '#999999',
+    'host':      '#84bd00',
+    'separator': '#84bd00',
+    'text':      '#e6e6e6',
+    'arrow':     '#999999',
+    'selectedtext': 'reverse underline',
+    'toolbar': '#e6e6e6 bg:#262626',
 })
 
 
 def completer():
-    list = []
+    s = set()
 
-    for name in history():
-        list.append(name)
+    history_strings = history().load_history_strings()
 
-    return WordCompleter(set(list), ignore_case=True)
+    for name in history_strings:
+        s.add(name)
+
+    return WordCompleter(list(s), ignore_case=True)
 
 
-def get_bottom_toolbar_tokens(currentSong):
-    def toolbar(cli):
+def get_bottom_toolbar(currentSong):
+    def toolbar():
         return [
-            (Token.Toolbar, ' exit: ctrl+d | clear: ctrl+c | song: %s' % currentSong)
+            ('class:toolbar', ' exit: ctrl+d | clear: ctrl+c | song: %s' % currentSong)
         ]
 
     return toolbar
 
 
-def get_prompt_tokens(cli):
+def get_prompt():
     return [
-        (Token.Username,  getpass.getuser()),
-        (Token.At,        '@'),
-        (Token.Host,      os.uname()[1]),
-        (Token.Separator, ' - '),
-        (Token.Text,      'Search:'),
-        (Token.Arrow,     '\n> '),
+        ('class:username',  getpass.getuser()),
+        ('class:at',        '@'),
+        ('class:host',      os.uname()[1]),
+        ('class:seperator', ' - '),
+        ('class:text',      'Search:'),
+        ('class:arrow',     '\n> '),
     ]
 
 
-def custom_prompt(currentSong):
-    return prompt(
-        get_prompt_tokens=get_prompt_tokens,
+def custom_prompt(currentSong): 
+    
+    session = PromptSession(
+        message=get_prompt,
         history=history(),
         auto_suggest=AutoSuggestFromHistory(),
         enable_history_search=True,
-        on_abort=AbortAction.RETRY,
-        get_bottom_toolbar_tokens=get_bottom_toolbar_tokens(currentSong),
+        bottom_toolbar=get_bottom_toolbar(currentSong),
         completer=completer(),
         complete_while_typing=True,
+        complete_in_thread=True,
         style=style
     )
+
+    return session.prompt()
+

--- a/pytify/pytifylib.py
+++ b/pytify/pytifylib.py
@@ -107,7 +107,8 @@ class Pytifylib:
     def print_history(self):
         print('\nLast ten entries from history:')
 
-        entries = history()
+        entries = history().load_history_strings()
+        entries = list(entries)
 
         qty = len(entries)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ### USAGE ###
 # pip install -r requirements.txt
 requests ~= 2.4.3
-prompt-toolkit ~= 1.0.15
+prompt-toolkit ~= 2.0.9
 spotipy ~= 2.3.8

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,14 @@ from setuptools import setup, find_packages
 
 __version__ = '3.5.1'
 
+def get_install_requires():
+    install_requires = []
+
+    with open("requirements.txt", "r") as req_txt:
+        install_requires = map(lambda s: s.strip(), req_txt.readlines()[2:])
+        
+    return list(install_requires)
+
 setup(
     name='pytify',
     version=__version__,
@@ -14,11 +22,7 @@ setup(
     license='MIT',
     keywords='spotify pytify song search curses',
     packages=find_packages(),
-    install_requires=[
-        'requests ~= 2.4.3',
-        'spotipy~=2.3.8',
-        'prompt-toolkit~=1.0.15'
-    ],
+    install_requires=get_install_requires(),
     entry_points={
         'console_scripts': [
             'pytify=pytify.cli:main'


### PR DESCRIPTION
This pull request adds support for prompt_toolkit v2 which introduced a lot of breaking changes which rendered Pytify useless. 

This change is split into 3 commits. Brief summary of each commit:
(i) add support in setup.py to requirements.txt for install_requires.
(ii) Add support for prompt_toolkit v2 (The change we have all been waiting for!)
(iii) Make prompt_toolkit v2 (2.0.9) default for Pytify.

Each commit has a more a detailed description.