### PR TITLE
Handle EOFError of prompt in interaction() method in class App

### DIFF
--- a/pytify/cli.py
+++ b/pytify/cli.py
@@ -73,7 +73,10 @@ class App:
                 search_input = custom_prompt(self.pytify.get_current_playing())
             except KeyboardInterrupt:
                 continue
-            
+            except EOFError:
+                print('\n Closing application...\n')
+                break
+
             if self.command.run(search_input):
                 continue
 
@@ -84,7 +87,4 @@ class App:
 
 
 def main():
-    try:
-        App()
-    except EOFError:
-        print('\n Closing application...\n')
+    App()


### PR DESCRIPTION
It is better to handle the EOFError(triggered when we hit ctrl + D)
in the interaction() method rather than handling it outside in __name__
== "__main__". This is to enhance readability of code. Since a
KeyBoardError or EOFError are associated with each new prompt session(a
new prompt session is defined after each iteration of the while loop),
it makes sense to move the error handling of EOFError to interaction
method.